### PR TITLE
- Fixed error when generating cert with argument "--it" should be "-it".

### DIFF
--- a/lego.env
+++ b/lego.env
@@ -1,7 +1,7 @@
 # Email for Let'sEncrypt cert issuance
 CERT_EMAIL='your@email.com'
-# The FQDN of your UDMP
-CERT_HOST='whatever.hostname.com'
+# The FQDN of your UDMP (comma separated fqdn is supported)
+CERT_HOST='whatever.hostname.com,*.whatever.hostname.com'
 # Create a Cloudflare API token with DNS:Edit & Zone:Read permissions limited to your zone
 CLOUDFLARE_DNS_API_TOKEN=''
 # Change stuff below at your own risk

--- a/lego.sh
+++ b/lego.sh
@@ -22,10 +22,10 @@ for DOM in $(echo $CERT_HOST | tr "," "\n")
 do
 	if [ -z "$CERT_NAME" ]
 	then
-		CERT_NAME $DOM
+		CERT_NAME=$DOM
 	fi
     
-	HOSTS_ARGS+="-d $DOM"
+	HOSTS_ARGS="${HOSTS_ARGS} -d $DOM"
 done
 
 deploy_cert() {

--- a/on_boot.d/99-lego-install.sh
+++ b/on_boot.d/99-lego-install.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+UDM_LEGO_PATH=/mnt/data/ssl
+
 if [ ! -f /etc/cron.d/lego ]; then
-    /mnt/data/ssl/lego.sh renew
+    $UDM_LEGO_PATH/lego.sh renew
 fi

--- a/on_boot.d/99-lego-install.sh
+++ b/on_boot.d/99-lego-install.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ ! -f /etc/cron.d/lego ]; then
+    /mnt/data/ssl/lego.sh renew
+fi


### PR DESCRIPTION
More features:

- Added support to SAN, now you can generate wildcard cert.
- Added support with on_boot to make all permanent if you have it installed, check:
	https://github.com/boostchicken/udm-utilities/tree/master/on-boot-script

Please, test it before merge.