### PR TITLE
fix: Issue 20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+serviceaccount/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-serviceaccount/*.json
+.aws/*
+.gcloud/*

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ This script is setup such that if it determines that on-boot-script is enabled, 
 
 AWS Route53 DNS challenge can use configuration and authentication values easily through shared credentials and configuration files [as described here](https://go-acme.github.io/lego/dns/route53/). This script will check for and include these files during the initial certificate generation and subsequent renewals. Ensure that `route53` is set for `DNS_PROVIDER` in `udm-le.env`, create a new directory called `.aws` in `/mnt/data/udm-le` and add `credentials` and `config` files as required for your authentication. See the [AWS CLI Documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) for more information. Currently only the `default` profile is supported.
 
+### GCP Cloud DNS
+
+GCP Cloud DNS can be configured by establishing a service account with the role `roles/dns.admin`. Ensure that the variable 
+`GCE_SERVICE_ACCOUNT_FILE` references the path to the service account file as exported from GCP. The `DNS_PROVIDER` in `udm-le.env` must be set to `gcloud`.
+
 ### Cloudflare
 
 In your Cloudflare account settings, create an API token with the following permissions:

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ AWS Route53 DNS challenge can use configuration and authentication values easily
 
 ### GCP Cloud DNS
 
-GCP Cloud DNS can be configured by establishing a service account with the role `roles/dns.admin`. Ensure that the variable 
-`GCE_SERVICE_ACCOUNT_FILE` references the path to the service account file as exported from GCP. The `DNS_PROVIDER` in `udm-le.env` must be set to `gcloud` and a new directory called `.gcloud` in `/mnt/data/udm-le` and add `credentials` and `config` files as required for authentication.
+GCP Cloud DNS can be configured by establishing a service account with the role [`roles/dns.admin`](https://cloud.google.com/iam/docs/understanding-roles#dns-roles) and exporting a [service account key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) for that service account. Ensure that `gcloud` is set for `DNS_PROVIDER` in `udm-le.env`, and `GCE_SERVICE_ACCOUNT_FILE` references the path to the service account key (e.g. `./root/.gcloud/my_service_account.json`) . Create a new directory called `.gcloud` in `/mnt/data/udm-le` and add the service account file.
 
 ### Cloudflare
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ AWS Route53 DNS challenge can use configuration and authentication values easily
 ### GCP Cloud DNS
 
 GCP Cloud DNS can be configured by establishing a service account with the role `roles/dns.admin`. Ensure that the variable 
-`GCE_SERVICE_ACCOUNT_FILE` references the path to the service account file as exported from GCP. The `DNS_PROVIDER` in `udm-le.env` must be set to `gcloud`.
+`GCE_SERVICE_ACCOUNT_FILE` references the path to the service account file as exported from GCP. The `DNS_PROVIDER` in `udm-le.env` must be set to `gcloud` and a new directory called `.gcloud` in `/mnt/data/udm-le` and add `credentials` and `config` files as required for authentication.
 
 ### Cloudflare
 

--- a/udm-le.env
+++ b/udm-le.env
@@ -6,7 +6,7 @@
 CERT_EMAIL='ken@duffenterprises.com'
 
 # The FQDN of your UDMP (comma separated fqdns are supported)
-CERT_HOSTS='udm2.management.duffenterprises.com'
+CERT_HOSTS='*.management.duffenterprises.com'
 
 # Enable updating Captive Portal certificate as well as device certificate
 ENABLE_CAPTIVE='no'
@@ -16,9 +16,11 @@ ENABLE_CAPTIVE='no'
 #CLOUDFLARE_DNS_API_TOKEN=YOUR_CLOUDFLARE_API_TOKEN
 #DNS_PROVIDER='cloudflare'
 
-# GCP Cloud DNS
-GCE_SERVICE_ACCOUNT_FILE=.gcloud/sa.json
+# GCP CloudDNS settings, see the README.md for information about other providers.
+# Note: The default path for the service account file is /root/.gcloud
+GCE_SERVICE_ACCOUNT_FILE=/root/.gcloud/sa.json
 DNS_PROVIDER='gcloud'
+GCE_PROPAGATION_TIMEOUT=3600
 
 
 #

--- a/udm-le.env
+++ b/udm-le.env
@@ -3,24 +3,24 @@
 #
 
 # Email for LetsEncrypt certificate issuance
-CERT_EMAIL='ken@duffenterprises.com'
+CERT_EMAIL='your@email.com'
 
 # The FQDN of your UDMP (comma separated fqdns are supported)
-CERT_HOSTS='*.management.duffenterprises.com'
+CERT_HOSTS='whatever.hostname.com,*.whatever.hostname.com'
 
 # Enable updating Captive Portal certificate as well as device certificate
 ENABLE_CAPTIVE='no'
 
 # CloudFlare settings, see the README.md for information about other providers
 # Note: Quoting your CLOUDFLARE_DNS_API_TOKEN below seems to cause issues
-#CLOUDFLARE_DNS_API_TOKEN=YOUR_CLOUDFLARE_API_TOKEN
-#DNS_PROVIDER='cloudflare'
+CLOUDFLARE_DNS_API_TOKEN=YOUR_CLOUDFLARE_API_TOKEN
+DNS_PROVIDER='cloudflare'
 
 # GCP CloudDNS settings, see the README.md for information about other providers.
 # Note: The default path for the service account file is /root/.gcloud
-GCE_SERVICE_ACCOUNT_FILE=/root/.gcloud/sa.json
-DNS_PROVIDER='gcloud'
-GCE_PROPAGATION_TIMEOUT=3600
+#GCE_SERVICE_ACCOUNT_FILE=/root/.gcloud/sa.json
+#DNS_PROVIDER='gcloud'
+#GCE_PROPAGATION_TIMEOUT=3600
 
 
 #

--- a/udm-le.env
+++ b/udm-le.env
@@ -6,15 +6,17 @@
 CERT_EMAIL='your@email.com'
 
 # The FQDN of your UDMP (comma separated fqdns are supported)
-CERT_HOSTS='whatever.hostname.com,*.whatever.hostname.com'
+CERT_HOSTS='udm.management.duffenterprises.com"
 
 # Enable updating Captive Portal certificate as well as device certificate
 ENABLE_CAPTIVE='no'
 
 # CloudFlare settings, see the README.md for information about other providers
 # Note: Quoting your CLOUDFLARE_DNS_API_TOKEN below seems to cause issues
-CLOUDFLARE_DNS_API_TOKEN=YOUR_CLOUDFLARE_API_TOKEN
-DNS_PROVIDER='cloudflare'
+#CLOUDFLARE_DNS_API_TOKEN=YOUR_CLOUDFLARE_API_TOKEN
+#DNS_PROVIDER='cloudflare'
+
+
 
 #
 # Change stuff below at your own risk

--- a/udm-le.env
+++ b/udm-le.env
@@ -6,7 +6,7 @@
 CERT_EMAIL='your@email.com'
 
 # The FQDN of your UDMP (comma separated fqdns are supported)
-CERT_HOSTS='whatever.hostname.com,*.whatever.hostname.com'
+CERT_HOSTS='whatever.hostname.com,*.whatever.anotherhostname.com'
 
 # Enable updating Captive Portal certificate as well as device certificate
 ENABLE_CAPTIVE='no'

--- a/udm-le.env
+++ b/udm-le.env
@@ -3,10 +3,10 @@
 #
 
 # Email for LetsEncrypt certificate issuance
-CERT_EMAIL='your@email.com'
+CERT_EMAIL='ken@duffenterprises.com'
 
 # The FQDN of your UDMP (comma separated fqdns are supported)
-CERT_HOSTS='udm2.management.duffenterprises.com"
+CERT_HOSTS='udm2.management.duffenterprises.com'
 
 # Enable updating Captive Portal certificate as well as device certificate
 ENABLE_CAPTIVE='no'
@@ -17,7 +17,7 @@ ENABLE_CAPTIVE='no'
 #DNS_PROVIDER='cloudflare'
 
 # GCP Cloud DNS
-GCE_SERVICE_ACCOUNT_FILE=./serviceaccount/sa.json
+GCE_SERVICE_ACCOUNT_FILE=.gcloud/sa.json
 DNS_PROVIDER='gcloud'
 
 

--- a/udm-le.env
+++ b/udm-le.env
@@ -6,7 +6,7 @@
 CERT_EMAIL='your@email.com'
 
 # The FQDN of your UDMP (comma separated fqdns are supported)
-CERT_HOSTS='udm.management.duffenterprises.com"
+CERT_HOSTS='udm2.management.duffenterprises.com"
 
 # Enable updating Captive Portal certificate as well as device certificate
 ENABLE_CAPTIVE='no'
@@ -16,6 +16,9 @@ ENABLE_CAPTIVE='no'
 #CLOUDFLARE_DNS_API_TOKEN=YOUR_CLOUDFLARE_API_TOKEN
 #DNS_PROVIDER='cloudflare'
 
+# GCP Cloud DNS
+GCE_SERVICE_ACCOUNT_FILE=./serviceaccount/sa.json
+DNS_PROVIDER='gcloud'
 
 
 #

--- a/udm-le.sh
+++ b/udm-le.sh
@@ -11,10 +11,8 @@ LEGO_ARGS="--dns ${DNS_PROVIDER} --email ${CERT_EMAIL} --key-type rsa2048"
 NEW_CERT=""
 
 deploy_cert() {
-	#Re-write CERT_NAME if it is a wildcard cert to replace * with _
-	LEGO_CERT_NAME=echo ${$CERT_NAME/#\*/_} 
-
-
+	#Re-write CERT_NAME if it is a wildcard cert. Replace * with _
+	LEGO_CERT_NAME=${CERT_NAME/\*/_}
 	if [ "$(find -L "${UDM_LE_PATH}"/lego -type f -name "${LEGO_CERT_NAME}".crt -mmin -5)" ]; then
 		echo 'New certificate was generated, time to deploy it'
 		# Controller certificate

--- a/udm-le.sh
+++ b/udm-le.sh
@@ -48,6 +48,12 @@ if [ -d "${UDM_LE_PATH}/.aws" ]; then
         DOCKER_VOLUMES="${DOCKER_VOLUMES} -v ${UDM_LE_PATH}/.aws:/root/.aws/"
 fi
 
+# Check for optional .gcloud directory, and add it to the mounts if it exists
+if [ -d "${UDM_LE_PATH}/.gcloud" ]; then
+        DOCKER_VOLUMES="${DOCKER_VOLUMES} -v ${UDM_LE_PATH}/.gcloud:/root/.gcloud/"
+fi
+
+
 # Setup persistent on_boot.d trigger
 ON_BOOT_DIR='/mnt/data/on_boot.d'
 ON_BOOT_FILE='99-udm-le.sh'


### PR DESCRIPTION
@kchristensen I've added the documentation to support gcloud, and modifications to the shell script. 

During my testing last week, I observered that the shell script did not support wildcard DNS entries. Let's Encrypt creates `*.whatever.anotherhostname.com` as `_.whatever.anotherhostname.com.cert` (etc) which is why I introduced the regex

```
LEGO_CERT_NAME=${CERT_NAME/\*/_}
```

I also observed that Let's Encrypt errored with domains like your original example:
```
CERT_HOSTS='whatever.hostname.com,*.whatever.hostname.com'
```
because whatever.hostname.com is encompased within `*.whatever.hostname.com`, thus the example update to `*.whatever.anotherhostname.com`. 

Hopefully this PR is useful to the UDM community. 
