### PR TITLE
Document Azure DNS configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-.aws/*
-.gcloud/*
+.secrets/*

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ This should work on UbiOS based firmware versions 1.7.0 onwards. This includes:
 
 This script supports issuing LetsEncrypt certificates via DNS using [Lego](https://go-acme.github.io/lego/).
 
-Out of the box, it has support for AWS Route53 and Cloudflare DNS providers, and with a bit of work you could
-get it working with any of the supported [Lego DNS Providers](https://go-acme.github.io/lego/dns/).
+Out of the box, it has tested support for select [DNS providers](#dns-providers) but with little work you could get it working with any of the supported [Lego DNS Providers](https://go-acme.github.io/lego/dns/).
 
 ## Installation
 
@@ -28,11 +27,11 @@ This script is setup such that if it determines that on-boot-script is enabled, 
 
 ### AWS Route53
 
-AWS Route53 DNS challenge can use configuration and authentication values easily through shared credentials and configuration files [as described here](https://go-acme.github.io/lego/dns/route53/). This script will check for and include these files during the initial certificate generation and subsequent renewals. Ensure that `route53` is set for `DNS_PROVIDER` in `udm-le.env`, create a new directory called `.aws` in `/mnt/data/udm-le` and add `credentials` and `config` files as required for your authentication. See the [AWS CLI Documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) for more information. Currently only the `default` profile is supported.
+AWS Route53 DNS challenge can use configuration and authentication values easily through shared credentials and configuration files [as described here](https://go-acme.github.io/lego/dns/route53/). This script will check for and include these files during the initial certificate generation and subsequent renewals. Ensure that `route53` is set for `DNS_PROVIDER` in `udm-le.env`, create a new directory called `.secrets` in `/mnt/data/udm-le` and add `credentials` and `config` files as required for your authentication. See the [AWS CLI Documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) for more information. Currently only the `default` profile is supported.
 
 ### GCP Cloud DNS
 
-GCP Cloud DNS can be configured by establishing a service account with the role [`roles/dns.admin`](https://cloud.google.com/iam/docs/understanding-roles#dns-roles) and exporting a [service account key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) for that service account. Ensure that `gcloud` is set for `DNS_PROVIDER` in `udm-le.env`, and `GCE_SERVICE_ACCOUNT_FILE` references the path to the service account key (e.g. `./root/.gcloud/my_service_account.json`) . Create a new directory called `.gcloud` in `/mnt/data/udm-le` and add the service account file.
+GCP Cloud DNS can be configured by establishing a service account with the role [`roles/dns.admin`](https://cloud.google.com/iam/docs/understanding-roles#dns-roles) and exporting a [service account key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) for that service account. Ensure that `gcloud` is set for `DNS_PROVIDER` in `udm-le.env`, and `GCE_SERVICE_ACCOUNT_FILE` references the path to the service account key (e.g. `./root/.secrets/my_service_account.json`) . Create a new directory called `.secrets` in `/mnt/data/udm-le` and add the service account file.
 
 ### Cloudflare
 
@@ -42,3 +41,21 @@ In your Cloudflare account settings, create an API token with the following perm
 * Zone > DNS > Edit
 
 Once you have your token generated, add the value to `udm-le.env`.
+
+### Azure DNS
+
+If not done already, [delegate a domain to an Azure DNS zone](https://docs.microsoft.com/en-us/azure/dns/dns-delegate-domain-azure-dns).
+
+Assuming the DNS zone lives in subscription `00000000-0000-0000-0000-000000000000` and resource group `udm-le`, with help of the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/) provision an identity to manage the DNS zone by running:
+
+```bash
+# login
+az login
+
+# create a service principal with contributor (default) permissions over the godns resource group
+az ad sp create-for-rbac --name godns --scope /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/udm-le
+```
+
+The CLI will output a JSON object. Use the printed properties to initialize your configuration in [udm-le.env](./udm-le.env).
+
+Note: the `password` value is a secret and as such you may want to omit it from [udm-le.env](./udm-le.env) and instead set it in a `.secrets/client-secret.txt` file.

--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ Assuming the DNS zone lives in subscription `00000000-0000-0000-0000-00000000000
 az login
 
 # create a service principal with contributor (default) permissions over the godns resource group
-az ad sp create-for-rbac --name godns --scope /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/udm-le
+az ad sp create-for-rbac --name godns --scope /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/udm-le --role contributor
 ```
 
 The CLI will output a JSON object. Use the printed properties to initialize your configuration in [udm-le.env](./udm-le.env).
 
-Note: the `password` value is a secret and as such you may want to omit it from [udm-le.env](./udm-le.env) and instead set it in a `.secrets/client-secret.txt` file.
+Note:
+- The `password` value is a secret and as such you may want to omit it from [udm-le.env](./udm-le.env) and instead set it in a `.secrets/client-secret.txt` file
+- The `appId` value is what [Lego](https://go-acme.github.io/lego/) calls a client id

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Out of the box, it has tested support for select [DNS providers](#dns-providers)
 
 ## Persistance
 
-On firmware updates, the cron file (`/etc/cron.d/udm-le`) gets removed, so if you'd like for this to persist between upgrades, I suggest so you install boostchicken's [on-boot-script](https://github.com/boostchicken/udm-utilities/tree/master/on-boot-script) package.
+On firmware updates or just reboots, the cron file (`/etc/cron.d/udm-le`) gets removed, so if you'd like for this to persist, I suggest so you install boostchicken's [on-boot-script](https://github.com/boostchicken/udm-utilities/tree/master/on-boot-script) package.
 
 This script is setup such that if it determines that on-boot-script is enabled, it will set up an additional script at `/mnt/data/on_boot.d/99-udm-le.sh` which will attempt certificate renewal shortly after a reboot (and subsequently set the cron back up again).
 

--- a/udm-le.env
+++ b/udm-le.env
@@ -11,17 +11,30 @@ CERT_HOSTS='whatever.hostname.com,*.whatever.anotherhostname.com'
 # Enable updating Captive Portal certificate as well as device certificate
 ENABLE_CAPTIVE='no'
 
-# CloudFlare settings, see the README.md for information about other providers
-# Note: Quoting your CLOUDFLARE_DNS_API_TOKEN below seems to cause issues
-CLOUDFLARE_DNS_API_TOKEN=YOUR_CLOUDFLARE_API_TOKEN
-DNS_PROVIDER='cloudflare'
+#
+# DNS provider configuration
+# See README.md file for more details
+#
 
-# GCP CloudDNS settings, see the README.md for information about other providers.
-# Note: The default path for the service account file is /root/.gcloud
-#GCE_SERVICE_ACCOUNT_FILE=/root/.gcloud/sa.json
+# CloudFlare
+# Note: Quoting your CLOUDFLARE_DNS_API_TOKEN below seems to cause issues
+DNS_PROVIDER='cloudflare'
+CLOUDFLARE_DNS_API_TOKEN=YOUR_CLOUDFLARE_API_TOKEN
+
+# GCP CloudDNS
+# Note: The default path for the service account file is /root/.secrets
 #DNS_PROVIDER='gcloud'
+#GCE_SERVICE_ACCOUNT_FILE=/root/.secrets/sa.json
 #GCE_PROPAGATION_TIMEOUT=3600
 
+# Azure
+#DNS_PROVIDER=azure
+#AZURE_CLIENT_ID=
+#AZURE_CLIENT_SECRET_FILE=/root/.secrets/client-secret.txt
+#AZURE_ENVIRONMENT=public
+#AZURE_RESOURCE_GROUP=udm-le
+#AZURE_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000
+#AZURE_TENANT_ID=
 
 #
 # Change stuff below at your own risk

--- a/udm-le.sh
+++ b/udm-le.sh
@@ -45,16 +45,10 @@ for DOMAIN in $(echo $CERT_HOSTS | tr "," "\n"); do
 	LEGO_ARGS="${LEGO_ARGS} -d ${DOMAIN}"
 done
 
-# Check for optional .aws directory, and add it to the mounts if it exists
-if [ -d "${UDM_LE_PATH}/.aws" ]; then
-        DOCKER_VOLUMES="${DOCKER_VOLUMES} -v ${UDM_LE_PATH}/.aws:/root/.aws/"
+# Check for optional .secrets directory, and add it to the mounts if it exists
+if [ -d "${UDM_LE_PATH}/.secrets" ]; then
+	DOCKER_VOLUMES="${DOCKER_VOLUMES} -v ${UDM_LE_PATH}/.secrets:/root/.secrets/"
 fi
-
-# Check for optional .gcloud directory, and add it to the mounts if it exists
-if [ -d "${UDM_LE_PATH}/.gcloud" ]; then
-        DOCKER_VOLUMES="${DOCKER_VOLUMES} -v ${UDM_LE_PATH}/.gcloud:/root/.gcloud/"
-fi
-
 
 # Setup persistent on_boot.d trigger
 ON_BOOT_DIR='/mnt/data/on_boot.d'


### PR DESCRIPTION
Hello 👋,

In this pull request, I am documenting how to use the [Azure provider](https://go-acme.github.io/lego/dns/azure/).

I am also proposing to use a single mount folder for additional settings/secrets that is not provider specific. I.e. replace `.gcloud` and `.aws` by `.secrets` (I don't mind about the name). I think it just makes it easier and more generic to configure the other providers Lego supports. Opinion?

I tested these changes on:

```
Model:       UniFi Dream Machine
Version:     1.8.5.2964
```

Note: on that new firmware, the cron tab does not seem to persist between reboots. I'll test https://github.com/boostchicken/udm-utilities/tree/master/on-boot-script.