### PR TITLE
Add Zonomi DNS & Option to Resolve CNAMES

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,9 @@ ocid1.compartment.oc1..secret
 1. Set the `DNS_PROVIDER` value to `"oraclecloud"`
 1. Uncomment and copy the values from each `~/.oci/config` variable to the similarly named `OCI_*` variable in `udm-le.env`.
 1. Create a new directory at `/mnt/data/udm-le/.secrets` and copy the `oci_api_key.pem` file that directory.
+
+### Zonomi
+
+If you use Zonomi as your DNS provider, set your `DNS_PROVIDER` to `zonomi` and configure your `ZONOMI_API_KEY`.
+
+The API key can be obtained [in your control panel](https://zonomi.com/app/cp/apikeys.jsp) under the dns key type.

--- a/udm-le.env
+++ b/udm-le.env
@@ -23,6 +23,13 @@ NO_BUNDLE='no'
 # Enable updating Radius support
 ENABLE_RADIUS='no'
 
+# Allows CNAMEs to be resolved. When true, allows resolving _acme-challenge.* in case it
+# has a CNAME pointing to a different domain. With this, make sure the DNS provider config
+# is for the provider the CNAME points to.
+#
+# Leave this disabled if you don't know what this means as most configurations don't need it.
+LEGO_EXPERIMENTAL_CNAME_SUPPORT=false
+
 #
 # DNS provider configuration
 # See README.md file for more details

--- a/udm-le.env
+++ b/udm-le.env
@@ -98,6 +98,10 @@ CLOUDFLARE_DNS_API_TOKEN=YOUR_CLOUDFLARE_API_TOKEN
 #OCI_USER_OCID=ocid1.user.oc1..secret
 #OCI_REGION=us-ashburn-1
 
+# Zonomi
+#DNS_PROVIDER='zonomi'
+#ZONOMI_API_KEY=AUTH_TOKEN
+
 #
 # Change stuff below at your own risk
 #


### PR DESCRIPTION
# Zonomi
Added and tested configuration for Zonomi DNS provider. 

# Resolve CNAMEs
I have also added the `LEGO_EXPERIMENTAL_CNAME_SUPPORT` variable ([from LEGO documentation](https://go-acme.github.io/lego/dns/#experimental-features)) along with a brief description.

This allows resolving `_acme-challenge.<YOUR_FQDN>`  in case it has a CNAME pointing to a different domain. With this, one can set a FQDN and then set up authentication for the DNS provider of the domain it points to*.

The default setting is 'false' as this won't interfere with the way the current configurations are and maintains the current behavior. Those who need it can enable it as they would be on the lookout for such an option.

This is an obscure setting and admittedly still 'experimental' according to LEGO, however I tested it and it worked out like a charm for my setup, so I wanted to increase visibility for anyone else in my situation. 

If this is not wanted, please let me know and I'll remove it to simply add Zonomi ☺

---
\*_An example setup would be requesting a cert for `DOMAIN_A.com` while setting a CNAME record with `DNS_PROVIDER_A` of `_acme.challenge.DOMAIN_A.com` pointing to `_acme.challenge.DOMAIN_B.com` , then in your config you can provide the API/password for `DNS_PROVIDER_B` who is in charge of `DOMAIN_B.com`_

_The config values for the above example would look something like this:_
- _`CERT_HOSTS='DOMAIN_A.com'`_
- _`LEGO_EXPERIMENTAL_CNAME_SUPPORT=true`_
- _`DNS_PROVIDER=DNS_PROVIDER_B`_
- _`DNS_PROVIDER_TOKEN=DNS_PROVIDER_B_API_KEY`_

_The benefit of this setup is that in case of an API key compromise only `DOMAIN_B.com` is exposed while not interfering with the DNS of your main domain (in this case `DOMAIN_A.com`). The damage would be limited in that an attacker would only be able to create TXT influencing `_acme.challenge.DOMAIN_A.com` (as well as full DNS control of `DOMAIN_B.com`, of course) but could quickly be mitigated by pointing `DOMAIN_A.com` away from `DOMAIN_B.com` with `DNS_PROVIDER_A`_