### PR TITLE
Feature/add unifios2.x support

### DIFF
--- a/on_boot.d/99-udm-le.sh
+++ b/on_boot.d/99-udm-le.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Load Environmnt Variables
-. /mnt/data/udm-le/udm-le.env
+. /persistent/udm-le/udm-le.env
 
 if [ ! -f /etc/cron.d/udm-le ]; then
 	# Sleep for 5 minutes to avoid restarting

--- a/on_boot.d/udm-le-startup.service
+++ b/on_boot.d/udm-le-startup.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=A oneshot service to ensure udm-le is in crontab
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c "/persistent/udm-le/on_boot.d/99-udm-le.sh"
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/udm-le.env
+++ b/udm-le.env
@@ -106,6 +106,13 @@ CLOUDFLARE_DNS_API_TOKEN=YOUR_CLOUDFLARE_API_TOKEN
 # Change stuff below at your own risk
 #
 
+# LEGO binary information
+LEGO_VERSION="4.10.2"
+BINARY_PATH="/usr/local/bin"
+LEGO_BINARY="lego_v${LEGO_VERSION}_linux_arm64.tar.gz"
+LEGO_PROJECT_URL="https://github.com/go-acme/lego"
+LEGO_BINARY_URL="${LEGO_PROJECT_URL}/releases/download/v${LEGO_VERSION}/${LEGO_BINARY}"
+
 # Container Image configuration
 CONTAINER_IMAGE='docker.io/goacme/lego'
 CONTAINER_IMAGE_TAG='v4.4.0-arm.v8'

--- a/udm-le.sh
+++ b/udm-le.sh
@@ -4,6 +4,8 @@ set -e
 
 # Load environment variables
 . /persistent/udm-le/udm-le.env
+# for local dev
+# . ./udm-le.env
 
 # Setup variables for later
 DOCKER_VOLUMES="-v ${UDM_LE_PATH}/lego/:/.lego/"
@@ -61,6 +63,23 @@ command_exists() {
 
 depends_on() {
   ! command_exists "${1:-}" && echo "Missing dependencie(s): \`$*\`" 1>&2 && exit 1
+}
+
+install_binary() {
+	# Download and install LEGO binary
+
+	depends_on wget
+	depends_on tar
+	wget --directory-prefix=/tmp ${LEGO_BINARY_URL}
+	# extract only the lego binary file from tarball with "no-same-owner (-o)" 
+	tar -xozf /tmp/${LEGO_BINARY} --directory=${BINARY_PATH} lego
+}
+
+setup_service() {
+	# Setup udm-le-startup.service to ensure udm-le is in cron.d after reboots / updates
+
+	depends_on systemctl
+	systemctl enable ${UDM_LE_PATH}/on_boot.d/udm-le-startup.service	
 }
 
 deploy_certs() {
@@ -145,7 +164,7 @@ if command_exists podman; then
 	PODMAN_CMD="podman exec -it unifi-os"
 	LEGO_PATH="${UDM_LE_PATH}/lego"
 else 
-	LEGO_CMD="/usr/local/bin/lego"
+	LEGO_CMD="${BINARY_PATH}/lego"
 	PODMAN_CMD=""
 	LEGO_PATH="${UDM_LE_PATH}/.lego"
 	UDM_LEGACY=false
@@ -191,19 +210,23 @@ else
 fi
 
 if [ ! -f "${CRON_FILE}" ]; then
-	echo $CRON_STRING >${CRON_FILE}
+	echo "${CRON_STRING}" > ${CRON_FILE}
 	chmod 644 ${CRON_FILE}
 	${CRON_CMD} reload ${CRON_FILE}
 fi
 
 case $1 in
 initial)
-	# Create lego directory so the container can write to it
-	if [ "$(stat -c '%u:%g' "${LEGO_PATH}")" != "1000:1000" ]; then
-		mkdir "${LEGO_PATH}"
-		chown 1000:1000 "${LEGO_PATH}"
+	if $UDM_LEGACY; then
+		# Create lego directory so the container can write to it
+		if [ "$(stat -c '%u:%g' "${LEGO_PATH}")" != "1000:1000" ]; then
+			mkdir "${LEGO_PATH}"
+			chown 1000:1000 "${LEGO_PATH}"
+		fi
+	else
+		install_binary
+		setup_service
 	fi
-
 	echo 'Attempting initial certificate generation'
 	${LEGO_CMD} ${LEGO_ARGS} --accept-tos run && deploy_certs && restart_services
 	;;

--- a/udm-le.sh
+++ b/udm-le.sh
@@ -91,9 +91,13 @@ deploy_certs() {
 
 restart_services() {
 	# Restart services if certificates have been deployed, or we're forcing it on the command line
-	if [ "${RESTART_SERVICES}" == true ]; then
+	if $RESTART_SERVICES; then
 		echo 'Restarting UniFi OS'
-		unifi-os restart &>/dev/null
+		if $UDM_LEGACY; then
+			unifi-os restart &>/dev/null
+		else
+			systemctl restart unifi-core
+		fi
 
 		if [ "$ENABLE_RADIUS" == "yes" ]; then
 			echo 'Restarting Radius server'

--- a/udm-le.sh
+++ b/udm-le.sh
@@ -5,7 +5,7 @@ set -e
 # Load environment variables
 . /persistent/udm-le/udm-le.env
 # for local dev
-# . ./udm-le.env
+. ./udm-le.env
 
 # Setup variables for later
 DOCKER_VOLUMES="-v ${UDM_LE_PATH}/lego/:/.lego/"
@@ -61,15 +61,9 @@ command_exists() {
   command -v "${1:-}" >/dev/null 2>&1
 }
 
-depends_on() {
-  ! command_exists "${1:-}" && echo "Missing dependencie(s): \`$*\`" 1>&2 && exit 1
-}
-
 install_binary() {
 	# Download and install LEGO binary
 
-	depends_on wget
-	depends_on tar
 	wget --directory-prefix=/tmp ${LEGO_BINARY_URL}
 	# extract only the lego binary file from tarball with "no-same-owner (-o)" 
 	tar -xozf /tmp/${LEGO_BINARY} --directory=${BINARY_PATH} lego
@@ -78,7 +72,6 @@ install_binary() {
 setup_service() {
 	# Setup udm-le-startup.service to ensure udm-le is in cron.d after reboots / updates
 
-	depends_on systemctl
 	systemctl enable ${UDM_LE_PATH}/on_boot.d/udm-le-startup.service	
 }
 

--- a/udm-le.sh
+++ b/udm-le.sh
@@ -97,9 +97,9 @@ restart_services() {
 
 		if [ "$ENABLE_RADIUS" == "yes" ]; then
 			echo 'Restarting Radius server'
-			if [ command_exists rc.radius ]; then 
+			if command_exists rc.radius; then 
 				rc.radius restart &>/dev/null
-			elif [ command_exists rc.radiusd ];then 
+			elif command_exists rc.radiusd;then 
 				rc.radiusd restart &>/dev/null
 			else
 				echo 'Radius command not found'
@@ -136,7 +136,7 @@ update_keystore() {
 }
 
 # Check if podman exists - if no, assume we're on UnifiOS 2.x+
-if [ command_exists podman ]; then 
+if command_exists podman; then 
 	LEGO_CMD="podman run --env-file=${UDM_LE_PATH}/udm-le.env -it --name=lego --network=host --rm ${DOCKER_VOLUMES} ${CONTAINER_IMAGE}:${CONTAINER_IMAGE_TAG}"
 	PODMAN_CMD="podman exec -it unifi-os"
 	LEGO_PATH="${UDM_LE_PATH}/lego"
@@ -178,7 +178,7 @@ fi
 # Setup nightly cron job
 # Slightly different for UnifiOS > 2.x
 CRON_FILE='/etc/cron.d/udm-le'
-if [ UDM_LEGACY ]; then
+if $UDM_LEGACY; then
 	CRON_STRING="0 3 * * * sh ${UDM_LE_PATH}/udm-le.sh renew"
 	CRON_CMD=/etc/init.d/crond
 else


### PR DESCRIPTION
Completed the support for UnifiOS 2.x+ that was previously started. I did my best to make this work for both the "legacy case" which still relies upon podman (as UnifiOS 1.x did) along with the newer 2.x / 3.x configuration. The "initial" switch adds in the initial download and setup of the latest LEGO binary, adds a startup service that removes the need for the external on_boot.d setup (which requires podman).