### PR TITLE
docs: tweak udm-le.env and README.md to use /data/udm-le/.secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Out of the box, it has tested support for select [DNS providers](#dns-providers)
 ## Installation
 
 1. Copy the contents of this repo to your device at `/data/udm-le`.
-2. Edit `/data/udm-le.env` and tweak variables to meet your needs.
-3. Run `/data/udm-le/udm-le.sh initial`. This will handle your initial certificate generation and setup a systemd service to start the service on boot, as well as a systemd timer to attempt certificate renewal each morning between 0300 and 0305.
+2. Edit `/data/udm-le/udm-le.env` and tweak variables to meet your needs.
+3. If necessary, create and populate the `/data/udm-le/.secrets` directory with the files required by your DNS provider.
+4. Run `/data/udm-le/udm-le.sh initial`. This will handle your initial certificate generation and setup a systemd service to start the service on boot, as well as a systemd timer to attempt certificate renewal each morning between 0300 and 0305.
 
 ## DNS Providers
 

--- a/udm-le.env
+++ b/udm-le.env
@@ -45,7 +45,7 @@ LEGO_EXPERIMENTAL_CNAME_SUPPORT=false
 # Azure
 #DNS_PROVIDER="azure"
 #AZURE_CLIENT_ID=
-#AZURE_CLIENT_SECRET_FILE=/root/.secrets/client-secret.txt
+#AZURE_CLIENT_SECRET_FILE=/data/udm-le/.secrets/client-secret.txt
 #AZURE_ENVIRONMENT=public
 #AZURE_RESOURCE_GROUP=udm-le
 #AZURE_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000
@@ -68,7 +68,7 @@ CLOUDFLARE_DNS_API_TOKEN=YOUR_CLOUDFLARE_API_TOKEN
 # Google Cloud DNS
 # Note: The default path for the service account file is /root/.secrets
 #DNS_PROVIDER="gcloud"
-#GCE_SERVICE_ACCOUNT_FILE=/root/.secrets/sa.json
+#GCE_SERVICE_ACCOUNT_FILE=/data/udm-le/.secrets/sa.json
 #GCE_PROPAGATION_TIMEOUT=3600
 
 # Linode DNS
@@ -94,7 +94,7 @@ CLOUDFLARE_DNS_API_TOKEN=YOUR_CLOUDFLARE_API_TOKEN
 #DNS_PROVIDER="oraclecloud"
 # If OCI_PRIVKEY_FILE is password protected, uncomment the following line:
 #OCI_PRIVKEY_PASS=password
-#OCI_PRIVKEY_FILE=/root/.secrets/oci_api_key.pem
+#OCI_PRIVKEY_FILE=/data/udm-le/.secrets/oci_api_key.pem
 # The following values can be found in ~/.oci/config after
 #OCI_PUBKEY_FINGERPRINT=00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
 #OCI_TENANCY_OCID=ocid1.tenancy.oc1..secret


### PR DESCRIPTION
Minor changes to support v2.0.0 of UniFi OS.

I can also confirm that 2.0.0 works with Oracle Cloud Infrastructure DNS, including WifiMan. I didn't test RADUIS though, because I don't use it personally.