### PR TITLE
Add custom upstream DNS resolver

### DIFF
--- a/udm-le.env
+++ b/udm-le.env
@@ -30,6 +30,11 @@ ENABLE_RADIUS="no"
 # Leave this disabled if you don't know what this means as most configurations don't need it.
 LEGO_EXPERIMENTAL_CNAME_SUPPORT=false
 
+# The DNS resolver used to verify records. Change this to a public DNS resolver if you have
+# modified your UDM's upstream DNS servers to point to an internal resolver that is the
+# authoritative name server for any domain that you are trying to request certificates for.
+DNS_RESOLVER="127.0.0.1:53"
+
 #
 # DNS provider configuration
 # See README.md file for more details

--- a/udm-le.sh
+++ b/udm-le.sh
@@ -9,7 +9,7 @@ source /data/udm-le/udm-le.env
 set +a
 
 # Setup additional variables for later
-LEGO_ARGS="--dns ${DNS_PROVIDER} --email ${CERT_EMAIL} --key-type rsa2048"
+LEGO_ARGS="--dns ${DNS_PROVIDER} --dns.resolvers ${DNS_RESOLVER} --email ${CERT_EMAIL} --key-type rsa2048"
 LEGO_FORCE_INSTALL=false
 RESTART_SERVICES=false
 


### PR DESCRIPTION
In Unifi Network, the upstream DNS resolver can be configured. This can be done in Settings > Internet under IPv4 Configuration.

In some cases, such as an environment with Microsoft Active Directory (AD) for a domain example.com, there may be a need to change the upstream DNS resolver to point to a DNS server within the internal network (i.e. the AD's DNS server) to handle all DNS queries for example.com.

When this is done, any certificate requests for the example.com domain and subdomains will fail to complete the initial local verification step because the upstream DNS server (i.e. AD server) is the authoritative name server for example.com and will not see the DNS changes applied to the external DNS provider, so it returns NXDOMAIN to LEGO.

To address the above issue, this commit adds a DNS_RESOLVER environment variable that is passed into the LEGO client in the `--dns.resolvers` flag to specific a different upstream DNS resolver to verify the new DNS entry locally. The default was chosen to be the loopback, as this was the one seen when LEGO was invoked by the script before these changes:

```
[INFO] [some.example.com] acme: use dns-01 solver
[INFO] [some.example.com] acme: Preparing to solve DNS-01
[INFO] cloudflare: new record for some.example.com, ID ########
[INFO] [some.example.com] acme: Trying to solve DNS-01
[INFO] [some.example.com] acme: Checking DNS record propagation using [127.0.0.1:53]
```

These changes were verified on a UDM SE running Unifi OS v3.2.7 and Network 8.0.24.