### PR TITLE
Add UDR to list of supported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This should work on UniFi devices running UniFi OS 2.x+, including:
 * UniFi Dream Machine
 * UniFi Dream Machine Pro
 * UniFi Dream Machine SE
+* UniFi Dream Router
 * UniFi Dream Wall
 * UniFi Network Video Recorder
 * UniFi Network Video Recorder Professional


### PR DESCRIPTION
Thanks for this script! I also used it on a UDR and it just works. Also running on UniFi OS 3.2.7 and Network 8.0.24.

---

This tiny PR adds the UniFi Dream Router to the list of supported devices in the README.