### PR TITLE
Add UX to the list of supported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This should work on UniFi devices running UniFi OS 2.x+, including:
 * UniFi Dream Machine SE
 * UniFi Dream Router
 * UniFi Dream Wall
+* UniFi Express
 * UniFi Network Video Recorder
 * UniFi Network Video Recorder Professional
 


### PR DESCRIPTION
This tiny PR adds the new UniFi Express (UX) to the list of supported devices in the readme.

Verified on Unifi OS 3.2.5 (Release Candidate) and Network 8.0.28.

---

![Screenshot from 2024-02-18 21-41-48 censored](https://github.com/kchristensen/udm-le/assets/6710854/0c89bf02-670f-401f-aee7-df13d36ee636)
