### PR TITLE
Update udm-le.sh

### DIFF
--- a/udm-le.sh
+++ b/udm-le.sh
@@ -99,8 +99,10 @@ restart_services() {
 		echo "restart_services(): Restarting unifi-core"
 		systemctl restart unifi-core &>/dev/null
 
-  		echo "restart_services(): Restarting unifi"
-		systemctl restart unifi &>/dev/null
+		if [ "$ENABLE_CAPTIVE" == "yes" ]; then
+	  		echo "restart_services(): Restarting unifi"
+			systemctl restart unifi &>/dev/null
+   		fi
 
 		if [ "$ENABLE_RADIUS" == "yes" ]; then
 			echo "restart_services(): Restarting freeradius server"

--- a/udm-le.sh
+++ b/udm-le.sh
@@ -99,6 +99,9 @@ restart_services() {
 		echo "restart_services(): Restarting unifi-core"
 		systemctl restart unifi-core &>/dev/null
 
+  		echo "restart_services(): Restarting unifi"
+		systemctl restart unifi &>/dev/null
+
 		if [ "$ENABLE_RADIUS" == "yes" ]; then
 			echo "restart_services(): Restarting freeradius server"
 			systemctl restart freeradius &>/dev/null


### PR DESCRIPTION
added restart of unifi.service, instead of just unifi-core.service. 
my udm-pro OS version 4.0.21 needed this restart in order to replace the captive portal certificate