### PR TITLE
Copy certs to eus_certificates directory for nginx on the cloud key gen 2 plus.

### DIFF
--- a/udm-le.env
+++ b/udm-le.env
@@ -144,3 +144,6 @@ UNIFIOS_CERT_PATH="/data/unifi-core/config"
 UNIFIOS_KEYSTORE_PATH="/usr/lib/unifi/data"
 UNIFIOS_KEYSTORE_CERT_ALIAS="unifi"
 UNIFIOS_KEYSTORE_PASSWORD="aircontrolenterprise"
+
+# Appears to be the path for nginx on UCK-G2-PLUS
+                                                              |  UNIFIEUS_CERT_PATH="/data/eus_certificates"

--- a/udm-le.sh
+++ b/udm-le.sh
@@ -13,6 +13,12 @@ LEGO_ARGS="--dns ${DNS_PROVIDER} --dns.resolvers ${DNS_RESOLVER} --email ${CERT_
 LEGO_FORCE_INSTALL=false
 RESTART_SERVICES=false
 
+# If the EUS cert directory exists, assume we need to
+# restart nginx along with the other services
+if [ -d ${UNIFIEUS_CERT_PATH} ]; then
+	RESTART_NGINX=yes
+fi
+
 # Show usage
 usage() {
 	echo "Usage: udm-le.sh action [ --restart-services ]"
@@ -79,6 +85,15 @@ deploy_certs() {
 		cp -f "${UDM_LE_PATH}"/.lego/certificates/"${LEGO_CERT_NAME}".key "${UBIOS_CONTROLLER_CERT_PATH}"/unifi-core.key
 		chmod 644 "${UBIOS_CONTROLLER_CERT_PATH}"/unifi-core.crt "${UBIOS_CONTROLLER_CERT_PATH}"/unifi-core.key
 
+		# Copy certs to the EUS directory. Based on the config
+		# at unifi-core/config/http/local-certs.conf
+		if [ "$RESTART_NGINX" == "yes" ]; then
+		    echo "Copying certs to ${UNIFIEUS_CERT_PATH} for nginx"
+		    cp -f "${UDM_LE_PATH}"/.lego/certificates/"${LEGO_CERT_NAME}".crt "${UNIFIEUS_CERT_PATH}"/unifi-os.crt
+		    cp -f "${UDM_LE_PATH}"/.lego/certificates/"${LEGO_CERT_NAME}".key "${UNIFIEUS_CERT_PATH}"/unifi-os.key
+		    chmod 644 "${UNIFIEUS_CERT_PATH}"/unifi-os.crt "${UNIFIEUS_CERT_PATH}"/unifi-os.key
+		fi
+
 		if [ "$ENABLE_CAPTIVE" == "yes" ]; then
 			update_keystore
 		fi
@@ -98,6 +113,11 @@ restart_services() {
 	if [ "${RESTART_SERVICES}" == true ]; then
 		echo "restart_services(): Restarting unifi-core"
 		systemctl restart unifi-core &>/dev/null
+
+		if [ "$RESTART_NGINX" == "yes" ]; then
+		    echo "restart_services(): Restarting nginx"
+		    systemctl reload nginx &>/dev/null
+		fi
 
 		if [ "$ENABLE_CAPTIVE" == "yes" ]; then
 	  		echo "restart_services(): Restarting unifi"

--- a/udm-le.sh
+++ b/udm-le.sh
@@ -115,7 +115,7 @@ restart_services() {
 		systemctl restart unifi-core &>/dev/null
 
 		if [ "$RESTART_NGINX" == "yes" ]; then
-		    echo "restart_services(): Restarting nginx"
+		    echo "restart_services(): Reloading nginx"
 		    systemctl reload nginx &>/dev/null
 		fi
 


### PR DESCRIPTION
The UCK-G2-PLUS uses nginx to front the various apps. Certificates for nginx are sourced from `/data/eus_certificates` directory. The main script has been modified to copy the crt and key files to the eus directory. It then issues a reload command to `nginx` to pick up the new cert files.

I'm not 100% certain this is on all `UCK-G2-PLUS` devices. I've seen some posts in forums that indicate the NVR uses the `eus_certificates` directory sometimes, but I have seen no explanation about why.

It might make sense to put a more robust check to see if nginx is present (not sure if it's used by all devices) or simply put an `ENABLE` flag into the env file. For now, I just assume if the `eus_certificates` directory exists, then `nginx` needs a reload.