### PR TITLE
Added EUS Certificate store support and parameter to force certificate location updates

### DIFF
--- a/udm-le.env
+++ b/udm-le.env
@@ -23,6 +23,9 @@ ENABLE_CAPTIVE="no"
 # a cached copy of the CA intermediate certificate(s) and are unable to download them.
 NO_BUNDLE="no"
 
+# Enable updating EUS Certificate
+ENABLE_EUS_CERTS="yes"
+
 # Defines the key type to be used.
 # Lego supported values are: RSA2048, RSA3072, RSA4096, RSA8192, EC256 and EC384, however
 # using values other than RSA2048 is known to cause issues with UniFiOS.
@@ -162,3 +165,4 @@ UNIFIOS_CERT_PATH="/data/unifi-core/config"
 UNIFIOS_KEYSTORE_PATH="/usr/lib/unifi/data"
 UNIFIOS_KEYSTORE_CERT_ALIAS="unifi"
 UNIFIOS_KEYSTORE_PASSWORD="aircontrolenterprise"
+UNIFIOS_EUS_CERT_PATH="/data/eus_certificates"

--- a/udm-le.sh
+++ b/udm-le.sh
@@ -85,6 +85,12 @@ deploy_certs() {
 		cp -f "${UDM_LE_PATH}"/.lego/certificates/"${LEGO_CERT_NAME}".key "${UBIOS_CONTROLLER_CERT_PATH}"/unifi-core.key
 		chmod 644 "${UBIOS_CONTROLLER_CERT_PATH}"/unifi-core.crt "${UBIOS_CONTROLLER_CERT_PATH}"/unifi-core.key
 
+		if [ "$ENABLE_EUS_CERTS" == "yes" ]; then
+			cp -f "${UDM_LE_PATH}"/.lego/certificates/"${LEGO_CERT_NAME}".crt "${UNIFIOS_EUS_CERT_PATH}"/unifi-os.crt
+			cp -f "${UDM_LE_PATH}"/.lego/certificates/"${LEGO_CERT_NAME}".key "${UNIFIOS_EUS_CERT_PATH}"/unifi-os.key
+			chmod 644 "${UNIFIOS_EUS_CERT_PATH}"/unifi-os.crt "${UNIFIOS_EUS_CERT_PATH}"/unifi-os.key
+		fi
+	
 		if [ "$ENABLE_CAPTIVE" == "yes" ]; then
 			update_keystore
 		fi


### PR DESCRIPTION
I have a Unifi Dream Machine SE and used to deploy certificates through the web interface.

While udm-le generated the certificates with no problem they never got pushed to the web UI.

I had a dig into where the certificates were located and found the `/data/eus_certificates` directory. This contains `unifi-os.crt` and `unifi-os.key` which by default are the self-signed unifi.local certificate.
If you upload a certificate via the web interface you get `<GUID>.crt` and `<GUID>.key` created. These get used for the web interface and get removed when you delete the certificate.
The web interface then falls back to the certificate in the `unifi-os.crt` and `unifi-os.key` files.

Since I do not want to wipe my config and start again, I cannot tell if the `unifi-os.crt` and `unifi-os.key` files only start to be used when you first upload a certificate via the web interface. Maybe others with a UDM SE want to test.


This pull request also add the ability to run with the parameter force_deploy_certs which just skips the 'has certs been updated in the last 5 minute` check.